### PR TITLE
Allow dispatcher_conf_dir and httpd_conf_dir to be the same directory.

### DIFF
--- a/manifests/author_dispatcher_set_config.pp
+++ b/manifests/author_dispatcher_set_config.pp
@@ -8,9 +8,11 @@ class aem_resources::author_dispatcher_set_config(
   $ssl_cert = '/etc/httpd/aem.disp-cert',
 ) {
 
-  file { "${dispatcher_conf_dir}":
+  file { unique([ $dispatcher_conf_dir, $httpd_conf_dir, ]):
     ensure => directory,
-  } -> file { "${dispatcher_conf_dir}/dispatcher.farms.any":
+  }
+
+  file { "${dispatcher_conf_dir}/dispatcher.farms.any":
     ensure  => file,
     content => epp('aem_resources/author-dispatcher.farms.any.epp', {
       author_host   => "${author_host}",
@@ -19,17 +21,17 @@ class aem_resources::author_dispatcher_set_config(
       docroot_dir   => "${docroot_dir}"
     }),
     mode    => '0664',
+    require =>  File[$dispatcher_conf_dir],
   }
 
-  file { "${httpd_conf_dir}":
-    ensure => directory,
-  } -> file { "${httpd_conf_dir}/1-puppet-aem-resources.conf":
+  file { "${httpd_conf_dir}/1-puppet-aem-resources.conf":
     ensure  => file,
     content => epp('aem_resources/httpd.conf.epp', {
       docroot_dir => $docroot_dir,
       ssl_cert    => $ssl_cert,
     }),
     mode    => '0664',
+    require => File[$httpd_conf_dir],
   }
 
 }

--- a/manifests/author_dispatcher_set_config.pp
+++ b/manifests/author_dispatcher_set_config.pp
@@ -8,7 +8,11 @@ class aem_resources::author_dispatcher_set_config(
   $ssl_cert = '/etc/httpd/aem.disp-cert',
 ) {
 
-  file { unique([ $dispatcher_conf_dir, $httpd_conf_dir, ]):
+  $conf_dirs = [ $dispatcher_conf_dir, $httpd_conf_dir, ]
+
+  $unique_conf_dirs = unique($conf_dirs)
+
+  file { $unique_conf_dirs:
     ensure => directory,
   }
 

--- a/manifests/publish_dispatcher_set_config.pp
+++ b/manifests/publish_dispatcher_set_config.pp
@@ -9,7 +9,11 @@ class aem_resources::publish_dispatcher_set_config(
   $ssl_cert = '/etc/httpd/aem.disp-cert',
 ) {
 
-  file { unique([ $dispatcher_conf_dir, $httpd_conf_dir, ]):
+  $conf_dirs = [ $dispatcher_conf_dir, $httpd_conf_dir, ]
+
+  $unique_conf_dirs = unique($conf_dirs)
+
+  file { $unique_conf_dirs:
     ensure => directory,
   }
 

--- a/manifests/publish_dispatcher_set_config.pp
+++ b/manifests/publish_dispatcher_set_config.pp
@@ -9,9 +9,11 @@ class aem_resources::publish_dispatcher_set_config(
   $ssl_cert = '/etc/httpd/aem.disp-cert',
 ) {
 
-  file { "${dispatcher_conf_dir}":
+  file { unique([ $dispatcher_conf_dir, $httpd_conf_dir, ]):
     ensure => directory,
-  } -> file { "${dispatcher_conf_dir}/dispatcher.farms.any":
+  }
+
+  file { "${dispatcher_conf_dir}/dispatcher.farms.any":
     ensure  => file,
     content => epp('aem_resources/publish-dispatcher.farms.any.epp', {
       publish_host   => "${publish_host}",
@@ -21,17 +23,17 @@ class aem_resources::publish_dispatcher_set_config(
       allowed_client => "${allowed_client}"
     }),
     mode    => '0664',
+    require =>  File[$dispatcher_conf_dir],
   }
 
-  file { "${httpd_conf_dir}":
-    ensure => directory,
-  } -> file { "${httpd_conf_dir}/1-puppet-aem-resources.conf":
+  file { "${httpd_conf_dir}/1-puppet-aem-resources.conf":
     ensure  => file,
     content => epp('aem_resources/httpd.conf.epp', {
       docroot_dir => $docroot_dir,
       ssl_cert    => $ssl_cert,
     }),
     mode    => '0664',
+    require => File[$httpd_conf_dir],
   }
 
 }


### PR DESCRIPTION
On Amazon linux `$dispatcher_conf_dir` and `$httpd_conf_dir` both point to the same directory so declaring both as a `File` resource fails. Instead, we use the `unique` function provided by `puppetlabs-stdlib` to ensure we only create File resources once.