### PR TITLE
Enhancement/stack provisioner52/add disable crxde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Remove port 443 listening from sample httpd.conf #21
 * Upgrade ruby_aem to 1.4.1 with nokogiri security vulnerability fix
 * Increase minimum ruby version requirement to 2.1
+* Added Puppet manifest to disable crxde
 
 ### 2.0.1
 * Fix incorrect aem_id source, was definition parameter, now package aem_id field

--- a/manifests/disable_crxde.pp
+++ b/manifests/disable_crxde.pp
@@ -1,0 +1,15 @@
+define aem_resources::disable_crxde(
+  $run_mode,
+  $aem_username = undef,
+  $aem_password = undef,
+  $aem_id = 'aem',
+) {
+
+  aem_bundle { "[${aem_id}] Stop davex bundle":
+    ensure       => stopped,
+    name         => 'org.apache.sling.jcr.davex',
+    aem_username => $aem_username,
+    aem_password => $aem_password,
+    aem_id       => $aem_id,
+  }
+}


### PR DESCRIPTION
Part 1

Added the feature to disable crxde the same way to enable it.

Regarding Issue https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/52