### PR TITLE
[ISSUE#47] Disabling CRXDE lite alias and absolute-uri

### DIFF
--- a/manifests/disable_crxde.pp
+++ b/manifests/disable_crxde.pp
@@ -11,5 +11,25 @@ define aem_resources::disable_crxde(
     aem_username => $aem_username,
     aem_password => $aem_password,
     aem_id       => $aem_id,
+  } -> aem_config_property { "[${aem_id}] Disable CRXDE Lite alias":
+    ensure           => absent,
+    name             => 'alias',
+    type             => 'String',
+    value            => '/crx/server',
+    run_mode         => $run_mode,
+    config_node_name => 'org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet',
+    aem_username     => $aem_username,
+    aem_password     => $aem_password,
+    aem_id           => $aem_id,
+  } -> aem_config_property { "[${aem_id}] Disable CRXDE Lite create-absolute-uri":
+    ensure           => absent,
+    name             => 'dav.create-absolute-uri',
+    type             => 'Boolean',
+    value            => false,
+    run_mode         => $run_mode,
+    config_node_name => 'org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet',
+    aem_username     => $aem_username,
+    aem_password     => $aem_password,
+    aem_id           => $aem_id,
   }
 }


### PR DESCRIPTION
Notes:
Disabling create-absolute-uri does untick the checkbox based on the  boolean value supplied.
It can be be disabled using below API.,
curl -u admin:admin -F "jcr:primaryType=sling:OsgiConfig" -F "alias=/crx/server" -F "dav.create-absolute-uri=true/false" -F "dav.create-absolute-uri@TypeHint=Boolean" https://ec2-ip:5433/apps/system/config/org.apache.sling.jcr.davex.impl.servlets.SlingDavExServlet



