### PR TITLE
Fixed parameter passing for aem_id in `enable_saml` manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed parameter passing for aem_id in `enable_saml` manifest #71
 
 ## [4.1.0] - 2019-07-19
 ### Changed

--- a/manifests/enable_saml.pp
+++ b/manifests/enable_saml.pp
@@ -105,6 +105,7 @@ define aem_resources::enable_saml(
       name    => 'org.apache.sling.security.impl.ReferrerFilter',
       path    => '/apps/system/config',
       type    => 'sling:OsgiConfig',
+      aem_id  => $aem_id,
       require => Aem_saml[aem_saml]
     } -> aem_config_property { "${aem_id}: allow empty referrer":
       ensure           => present,
@@ -112,6 +113,7 @@ define aem_resources::enable_saml(
       type             => 'Boolean',
       value            => true, # False or true ? Def OpenCloud False SAML package is true
       run_mode         => $aem_id,
+      aem_id           => $aem_id,
       config_node_name => 'org.apache.sling.security.impl.ReferrerFilter',
     } -> aem_config_property { "${aem_id}: Set allowed hosts regexp":
       ensure           => present,
@@ -119,6 +121,7 @@ define aem_resources::enable_saml(
       type             => 'String[]',
       value            => [''],
       run_mode         => $aem_id,
+      aem_id           => $aem_id,
       config_node_name => 'org.apache.sling.security.impl.ReferrerFilter',
     } -> aem_config_property { "${aem_id}: Set allowed methods":
       ensure           => present,
@@ -126,6 +129,7 @@ define aem_resources::enable_saml(
       type             => 'String[]',
       value            => ['POST', 'PUT', 'DELETE'],
       run_mode         => $aem_id,
+      aem_id           => $aem_id,
       config_node_name => 'org.apache.sling.security.impl.ReferrerFilter',
     } -> aem_config_property { "${aem_id}: Set allowed hosts":
       ensure           => present,
@@ -133,6 +137,7 @@ define aem_resources::enable_saml(
       type             => 'String[]',
       value            => [$idp_hostname],
       run_mode         => $aem_id,
+      aem_id           => $aem_id,
       config_node_name => 'org.apache.sling.security.impl.ReferrerFilter',
     }
 


### PR DESCRIPTION
Fixed parameter passing for aem_id in `enable_saml` manifest. With this change the config_node_property modules will consume the same environment variables as the `aem_saml` module. As atm both are expecting different environment variables. `aem_saml` expecct e.g. `author_username` while the `config_node_property` expects `aem_username`.

With this change both are expecting the same env variables e.g. `author_username`. 