### PR TITLE
Refactor `aem_saml` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Refactor `aem_saml` module to use `swaqger_aem_osgi` API Client for setting SAML configuration
+
 ## [5.5.0] - 2020-04-05
 ### Removed
 - Remove author scene7 replication agent


### PR DESCRIPTION
As part of the ugprade to ruby_aem #90  the `aem_saml` module was refactored to use the new swagger_aem_osgi client to set the SAML OSGI configuration