### PR TITLE
Lockdown version of `concurrent-ruby` to `1.1.9` #RS-126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.7.0] - 2022-09-06
 ### Changed
 - Upgrade ruby_aem to 3.14.0
-- Lockdown version of `concurrent-ruby` to `1.0.9` #RS-126
+- Lockdown version of `concurrent-ruby` to `1.1.9` #RS-126
 
 ## [7.6.1] - 2022-08-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.7.0] - 2022-09-06
 ### Changed
 - Upgrade ruby_aem to 3.14.0
+- Lockdown version of `concurrent-ruby` to `1.0.9` #RS-126
 
 ## [7.6.1] - 2022-08-31
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ when /darwin/
   gem 'CFPropertyList'
 end
 
+gem 'concurrent-ruby', '1.1.9', require: false
 gem 'facter', '4.2.11', require: false
 gem 'metadata-json-lint', '3.0.2', require: false
 gem 'puppet', '7.18.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.1.9)
     cri (2.15.11)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
@@ -165,6 +165,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  concurrent-ruby (= 1.1.9)
   facter (= 4.2.11)
   metadata-json-lint (= 3.0.2)
   puppet (= 7.18.0)


### PR DESCRIPTION
### Changed
- Lockdown version of `concurrent-ruby` to `1.1.9` #RS-126