### PR TITLE
Feature/add support for alias update for flush agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added the possibility to configure the aliasUpdate for a replication flush agent.
 
 ## [7.11.0] - 2024-07-31
 ### Changed

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Flush agent
       dest_base_url => 'http://somehost:8080',
       log_level     => 'info',
       retry_delay   => 60000,
+      alias_update  => true,  
       force         => true,
     }
 

--- a/lib/puppet/provider/aem_flush_agent/aem.rb
+++ b/lib/puppet/provider/aem_flush_agent/aem.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:aem_flush_agent).provide(:aem, parent: PuppetX::ShineSolution
   # Create a flush agent.
   def create
     flush_agent = client(resource).flush_agent(resource[:run_mode], resource[:name])
-    opts = { log_level: resource[:log_level], retry_delay: resource[:retry_delay] }
+    opts = { alias_update: resource[:alias_update], log_level: resource[:log_level], retry_delay: resource[:retry_delay] }
     result = flush_agent.create_update(resource[:title], resource[:description], resource[:dest_base_url], opts)
     handle(result)
   end

--- a/lib/puppet/type/aem_flush_agent.rb
+++ b/lib/puppet/type/aem_flush_agent.rb
@@ -81,4 +81,11 @@ Puppet::Type.newtype(:aem_flush_agent) do
       value = false if value == ''
     end
   end
+
+  newparam :alias_update do
+    desc 'AEM flush agent alias update'
+    validate do |value|
+      value = false if value == ''
+    end
+  end
 end

--- a/test/integration/resources/20_aem_flush_agent_present.pp
+++ b/test/integration/resources/20_aem_flush_agent_present.pp
@@ -7,5 +7,6 @@ aem_flush_agent { 'Create/update flush agent':
   dest_base_url => 'http://somehost:8080',
   log_level     => 'info',
   retry_delay   => 60000,
+  alias_update  => true,
   force         => true,
 }


### PR DESCRIPTION
Requires a new release of swagger-aem & ruby_aem (dependency should be bumped after release has been created):

- https://github.com/shinesolutions/swagger-aem/pull/91
- https://github.com/shinesolutions/ruby_aem/pull/47